### PR TITLE
Migrate from master and slave words

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -49,7 +49,7 @@ class MainWindow(QtGui.QMainWindow):
 
     def __init__(self, app,
                     confirm_exit=True,
-                    new_frontend_factory=None, slave_frontend_factory=None,
+                    new_frontend_factory=None, subordinate_frontend_factory=None,
                 ):
         """ Create a tabbed MainWindow for managing IPython FrontendWidgets
         
@@ -62,7 +62,7 @@ class MainWindow(QtGui.QMainWindow):
         new_frontend_factory : callable
             A callable that returns a new IPythonWidget instance, attached to
             its own running kernel.
-        slave_frontend_factory : callable
+        subordinate_frontend_factory : callable
             A callable that takes an existing IPythonWidget, and  returns a new 
             IPythonWidget instance, attached to the same kernel.
         """
@@ -72,7 +72,7 @@ class MainWindow(QtGui.QMainWindow):
         self._app = app
         self.confirm_exit = confirm_exit
         self.new_frontend_factory = new_frontend_factory
-        self.slave_frontend_factory = slave_frontend_factory
+        self.subordinate_frontend_factory = subordinate_frontend_factory
 
         self.tab_widget = QtGui.QTabWidget(self)
         self.tab_widget.setDocumentMode(True)
@@ -127,12 +127,12 @@ class MainWindow(QtGui.QMainWindow):
         current_widget = self.tab_widget.currentWidget()
         current_widget_index = self.tab_widget.indexOf(current_widget)
         current_widget_name = self.tab_widget.tabText(current_widget_index)
-        widget = self.slave_frontend_factory(current_widget)
-        if 'slave' in current_widget_name:
-            # don't keep stacking slaves
+        widget = self.subordinate_frontend_factory(current_widget)
+        if 'subordinate' in current_widget_name:
+            # don't keep stacking subordinates
             name = current_widget_name
         else:
-            name = '(%s) slave' % current_widget_name
+            name = '(%s) subordinate' % current_widget_name
         self.add_tab_with_frontend(widget,name=name)
 
     def close_tab(self,current_tab):
@@ -152,30 +152,30 @@ class MainWindow(QtGui.QMainWindow):
         # when trying to be closed, widget might re-send a request to be
         # closed again, but will be deleted when event will be processed. So
         # need to check that widget still exists and skip if not. One example
-        # of this is when 'exit' is sent in a slave tab. 'exit' will be
-        # re-sent by this function on the master widget, which ask all slave
+        # of this is when 'exit' is sent in a subordinate tab. 'exit' will be
+        # re-sent by this function on the main widget, which ask all subordinate
         # widgets to exit
         if closing_widget==None:
             return
 
-        #get a list of all slave widgets on the same kernel.
-        slave_tabs = self.find_slave_widgets(closing_widget)
+        #get a list of all subordinate widgets on the same kernel.
+        subordinate_tabs = self.find_subordinate_widgets(closing_widget)
 
         keepkernel = None #Use the prompt by default
         if hasattr(closing_widget,'_keep_kernel_on_exit'): #set by exit magic
             keepkernel = closing_widget._keep_kernel_on_exit
             # If signal sent by exit magic (_keep_kernel_on_exit, exist and not None)
-            # we set local slave tabs._hidden to True to avoid prompting for kernel
+            # we set local subordinate tabs._hidden to True to avoid prompting for kernel
             # restart when they get the signal. and then "forward" the 'exit'
             # to the main window
             if keepkernel is not None:
-                for tab in slave_tabs:
+                for tab in subordinate_tabs:
                     tab._hidden = True
-                if closing_widget in slave_tabs:
+                if closing_widget in subordinate_tabs:
                     try :
-                        self.find_master_tab(closing_widget).execute('exit')
+                        self.find_main_tab(closing_widget).execute('exit')
                     except AttributeError:
-                        self.log.info("Master already closed or not local, closing only current tab")
+                        self.log.info("Main already closed or not local, closing only current tab")
                         self.tab_widget.removeTab(current_tab)
                     self.update_tab_bar_visibility()
                     return
@@ -212,9 +212,9 @@ class MainWindow(QtGui.QMainWindow):
                     box.setIconPixmap(pixmap)
                     reply = box.exec_()
                     if reply == 1: # close All
-                        for slave in slave_tabs:
-                            background(slave.kernel_manager.stop_channels)
-                            self.tab_widget.removeTab(self.tab_widget.indexOf(slave))
+                        for subordinate in subordinate_tabs:
+                            background(subordinate.kernel_manager.stop_channels)
+                            self.tab_widget.removeTab(self.tab_widget.indexOf(subordinate))
                         closing_widget.execute("exit")
                         self.tab_widget.removeTab(current_tab)
                         background(kernel_manager.stop_channels)
@@ -239,9 +239,9 @@ class MainWindow(QtGui.QMainWindow):
         else: #close console and kernel (no prompt)
             self.tab_widget.removeTab(current_tab)
             if kernel_manager and kernel_manager.channels_running:
-                for slave in slave_tabs:
-                    background(slave.kernel_manager.stop_channels)
-                    self.tab_widget.removeTab(self.tab_widget.indexOf(slave))
+                for subordinate in subordinate_tabs:
+                    background(subordinate.kernel_manager.stop_channels)
+                    self.tab_widget.removeTab(self.tab_widget.indexOf(subordinate))
                 kernel_manager.shutdown_kernel()
                 background(kernel_manager.stop_channels)
         
@@ -269,7 +269,7 @@ class MainWindow(QtGui.QMainWindow):
         if widget_index > 0 :
             self.tab_widget.setCurrentIndex(widget_index)
 
-    def find_master_tab(self,tab,as_list=False):
+    def find_main_tab(self,tab,as_list=False):
         """
         Try to return the frontend that owns the kernel attached to the given widget/tab.
 
@@ -278,8 +278,8 @@ class MainWindow(QtGui.QMainWindow):
             on different ip use same port number.
 
             This function does the conversion tabNumber/widget if needed.
-            Might return None if no master widget (non local kernel)
-            Will crash IPython if more than 1 masterWidget
+            Might return None if no main widget (non local kernel)
+            Will crash IPython if more than 1 mainWidget
 
             When asList set to True, always return a list of widget(s) owning
             the kernel. The list might be empty or containing several Widget.
@@ -298,17 +298,17 @@ class MainWindow(QtGui.QMainWindow):
         filtered_widget_list = [ widget for widget in widget_list if
                                 widget.kernel_manager.connection_file == km.connection_file and
                                 hasattr(widget,'_may_close') ]
-        # the master widget is the one that may close the kernel
-        master_widget= [ widget for widget in filtered_widget_list if widget._may_close]
+        # the main widget is the one that may close the kernel
+        main_widget= [ widget for widget in filtered_widget_list if widget._may_close]
         if as_list:
-            return master_widget
-        assert(len(master_widget)<=1 )
-        if len(master_widget)==0:
+            return main_widget
+        assert(len(main_widget)<=1 )
+        if len(main_widget)==0:
             return None
 
-        return master_widget[0]
+        return main_widget[0]
 
-    def find_slave_widgets(self,tab):
+    def find_subordinate_widgets(self,tab):
         """return all the frontends that do not own the kernel attached to the given widget/tab.
 
             Only find frontends owned by the current application. Selection
@@ -329,10 +329,10 @@ class MainWindow(QtGui.QMainWindow):
                                 widget.kernel_manager.connection_file == km.connection_file)
         # Get a list of all widget owning the same kernel and removed it from
         # the previous cadidate. (better using sets ?)
-        master_widget_list = self.find_master_tab(tab, as_list=True)
-        slave_list = [widget for widget in filtered_widget_list if widget not in master_widget_list]
+        main_widget_list = self.find_main_tab(tab, as_list=True)
+        subordinate_list = [widget for widget in filtered_widget_list if widget not in main_widget_list]
 
-        return slave_list
+        return subordinate_list
 
     # Populate the menu bar with common actions and shortcuts
     def add_menu_action(self, menu, action, defer_shortcut=False):
@@ -369,11 +369,11 @@ class MainWindow(QtGui.QMainWindow):
             triggered=self.create_tab_with_new_frontend)
         self.add_menu_action(self.file_menu, self.new_kernel_tab_act)
 
-        self.slave_kernel_tab_act = QtGui.QAction("New Tab with Sa&me kernel",
+        self.subordinate_kernel_tab_act = QtGui.QAction("New Tab with Sa&me kernel",
             self,
             shortcut="Ctrl+Shift+T",
             triggered=self.create_tab_with_current_kernel)
-        self.add_menu_action(self.file_menu, self.slave_kernel_tab_act)
+        self.add_menu_action(self.file_menu, self.subordinate_kernel_tab_act)
         
         self.file_menu.addSeparator()
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.